### PR TITLE
Comment only on issues created by you

### DIFF
--- a/src/events/CommentOnIssue.ts
+++ b/src/events/CommentOnIssue.ts
@@ -38,21 +38,23 @@ export class CommentOnIssue implements HandleEvent<any> {
         const issue = e.data.Issue[0];
         const authorizingGithubUser = whoami(this.githubToken);
 
-        // To see these messages, configure Atomist in any slack channel: `@atomist-bot repo <repository-name>` 
+        // To see these messages, configure Atomist in any slack channel: `@atomist-bot repo <repository-name>`
         // Then create an issue in <repository-name> to see this notification in that channel!
-        const postInLinkedChannels = ctx.messageClient.addressChannels(`Got a new issue \`${issue.number}# ${issue.title}\``,
-            issue.repo.channels.map(c => c.name));
+        const postInLinkedChannels =
+            ctx.messageClient.addressChannels(`Got a new issue \`${issue.number}# ${issue.title}\``,
+                issue.repo.channels.map(c => c.name));
 
         const commentOnIssue = postInLinkedChannels
             .then(() =>
                 authorizingGithubUser.then(me => {
                     // Only comment on issues that I created. Take out this condition to comment on all issues!
-                    if (issue.openedBy.login === me)
+                    if (issue.openedBy.login === me) {
                         // tslint:disable-next-line:max-line-length
                         return axios.post(`https://api.github.com/repos/${issue.repo.owner}/${issue.repo.name}/issues/${issue.number}/comments`,
                             { body: "Hey, I saw your issue!" },
                             { headers: { Authorization: `token ${this.githubToken}` } });
-                    else {
+                    } else {
+                        // tslint:disable-next-line:max-line-length
                         console.log(`This issue was created by ${issue.openedBy.login} and I am ${me} so I will not comment on it.`);
                         return;
                     }

--- a/src/events/CommentOnIssue.ts
+++ b/src/events/CommentOnIssue.ts
@@ -6,6 +6,7 @@ import {
     HandlerResult,
     Secret,
     Secrets,
+    Success,
     Tags,
 } from "@atomist/automation-client/Handlers";
 import axios from "axios";
@@ -15,6 +16,9 @@ import axios from "axios";
   Issue {
     number
     title
+    openedBy {
+        login
+    }
     repo {
       owner
       name
@@ -32,17 +36,37 @@ export class CommentOnIssue implements HandleEvent<any> {
 
     public handle(e: EventFired<any>, ctx: HandlerContext): Promise<HandlerResult> {
         const issue = e.data.Issue[0];
+        const authorizingGithubUser = whoami(this.githubToken);
 
-        return ctx.messageClient.addressChannels(`Got a new issue \`${issue.number}# ${issue.title}\``,
-            issue.repo.channels.map(c => c.name))
-            .then(() => {
-                // tslint:disable-next-line:max-line-length
-                return axios.post(`https://api.github.com/repos/${issue.repo.owner}/${issue.repo.name}/issues/${issue.number}/comments`,
-                    { body: "Hey, I saw your issue!" },
-                    { headers: { Authorization: `token ${this.githubToken}` } });
-            })
-            .then(() => {
-                return Promise.resolve({ code: 0 });
-            });
+        // To see these messages, configure Atomist in any slack channel: `@atomist-bot repo <repository-name>` 
+        // Then create an issue in <repository-name> to see this notification in that channel!
+        const postInLinkedChannels = ctx.messageClient.addressChannels(`Got a new issue \`${issue.number}# ${issue.title}\``,
+            issue.repo.channels.map(c => c.name));
+
+        const commentOnIssue = postInLinkedChannels
+            .then(() =>
+                authorizingGithubUser.then(me => {
+                    // Only comment on issues that I created. Take out this condition to comment on all issues!
+                    if (issue.openedBy.login === me)
+                        // tslint:disable-next-line:max-line-length
+                        return axios.post(`https://api.github.com/repos/${issue.repo.owner}/${issue.repo.name}/issues/${issue.number}/comments`,
+                            { body: "Hey, I saw your issue!" },
+                            { headers: { Authorization: `token ${this.githubToken}` } });
+                    else {
+                        console.log(`This issue was created by ${issue.openedBy.login} and I am ${me} so I will not comment on it.`);
+                        return;
+                    }
+                }));
+        return commentOnIssue.then(() => {
+            return Success;
+        });
     }
+}
+
+function whoami(githubToken: string): Promise<string> {
+    const githubUser = axios.get(
+        `https://api.github.com/user`,
+        { headers: { Authorization: `token ${githubToken}` } })
+        .then(response => response.data.login);
+    return githubUser;
 }


### PR DESCRIPTION
If someone chooses to try Atomist, and they spin up the samples in their team, and anyone else in the entire org creates or updates an issue, then our person will comment on the issue with "I see your issue!"

That could be embarrassing.

This makes the issue-responding sample only comment on issues created by the person running the automation.
I don't know if this is the cleanest way to make this less intrusive, but it is one way. I really don't want people to be startled by the consequences of trying this out.

FYI: this also fires on updates to issues. Not comments, but assigning a person, for instance.